### PR TITLE
At 33 adaptar processador de dados ao mongo db

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,125 @@
+# Atmos Processador de Dados
+
+Processador que busca leituras registradas no MongoDB Atlas, valida se existe estrutura correspondente no PostgreSQL (servico Atmos-backend) e persiste os valores na tabela "valor_capturado". Depois da reconciliacao os documentos, tenham sido aceitos ou rejeitados, sao removidos da colecao no Mongo.
+
+## Requisitos
+- Node.js 18+ (desenvolvido com Node 22)
+- Dependencias instaladas com `npm install`
+- Banco PostgreSQL acessivel (o mesmo do Atmos-backend)
+- Cluster MongoDB Atlas contendo a colecao com as leituras
+
+## Variaveis de ambiente
+Crie um arquivo `.env` com o seguinte conteudo:
+
+```env
+# MongoDB Atlas
+MONGO_URI=mongodb+srv://<usuario>:<senha>@<cluster>.mongodb.net/?retryWrites=true&w=majority&appName=<app>
+MONGO_DB=Atmos
+MONGO_COLLECTION=datas_teste
+
+# PostgreSQL
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_NAME=postgres
+DB_USER=postgres
+DB_PASSWORD=admin123456
+```
+
+Campos obrigatorios:
+- `MONGO_URI`: string de conexao gerada pelo Atlas.
+- `MONGO_DB`: banco logico onde a colecao esta armazenada.
+- `MONGO_COLLECTION`: colecao com documentos no formato { UUID, unixtime, chave: valor }.
+- Credenciais `DB_*`: mesmas usadas pelo Atmos-backend.
+
+### Preparando os dados de teste no Atlas
+Caso os dados originais estejam em outra colecao (ex.: `datas`), replique-os para a colecao utilizada pelo processador (`datas_teste`). Uma maneira pratica usando o Atlas Data Explorer:
+
+1. Abra o cluster no Atlas e acesse **Collections**.
+2. Selecione o banco de origem (ex.: `Atmos`) e a colecao `datas`.
+3. Clique em **Collection Actions → Duplicate Collection**.
+4. Nomeie a nova colecao como `datas_teste` (no mesmo banco) e confirme. O Atlas criara uma copia completa.
+
+Alternativa via `mongosh` (reutilize a mesma URI que voce configurou em `MONGO_URI`, incluindo `appName`/parametros extras):
+
+```bash
+mongosh "mongodb+srv://admin:fogueiramagica@atmos.fath8uu.mongodb.net/?retryWrites=true&w=majority&appName=Atmos" \
+  --eval 'db.datas_teste.aggregate([{ $match: {} }, { $out: "datas_teste_1" }])'
+```
+
+Se o comando retornar `querySrv ENOTFOUND`, confira se o host do cluster (`<cluster>.mongodb.net`) esta correto — por exemplo, `atmos.fath8uu.mongodb.net` — exatamente como aparece na string de conexao fornecida pelo Atlas.
+
+Certifique-se de que a nova colecao esta apontada em `MONGO_COLLECTION` antes de iniciar o processador.
+
+#### Passo a passo via `mongosh`
+1. Abra o shell conectado ao cluster (mesma URI usada em `MONGO_URI`):
+   ```bash
+   mongosh "mongodb+srv://<usuario>:<senha>@<cluster>.mongodb.net/Atmos?retryWrites=true&w=majority&appName=<app>"
+   ```
+2. No prompt do shell selecione o banco:
+   ```javascript
+   use Atmos
+   ```
+3. Copie a colecao original para `datas_teste`:
+   ```javascript
+   db.datas.aggregate([{ $match: {} }, { $out: "datas_teste" }])
+   ```
+4. Digite `exit` para sair.
+
+## Principais arquivos
+
+| Caminho | Descricao |
+| ------- | --------- |
+| `src/index.ts` | Bootstrap do servidor Express. Conecta ao Mongo, executa sincronizacao inicial, liga o watcher de inserts e registra as rotas. Tambem trata o encerramento gracioso (SIGINT/SIGTERM). |
+| `src/config/mongo.ts` | Helpers do MongoDB Atlas (`connectMongoDB`, `getMongoCollection`, `disconnectMongoDB`). Usa `MONGO_DB` para abrir o banco correto. |
+| `src/config/database.ts` | Configuracao do Sequelize apontando para o PostgreSQL. |
+| `src/services/mongoToPostgresSync.ts` | Servico principal de sincronizacao. Valida UUID/parametros, grava em `valor_capturado`, gera resumo e remove os documentos tratados. |
+| `src/services/mongoWatcher.ts` | Change stream watcher. Ao detectar novos inserts dispara a sincronizacao, com controle para evitar execucoes concorrentes e retry basico. |
+| `src/repository/postgresSyncRepository.ts` | Consultas SQL usadas para buscar estacao, parametros vinculados e inserir valores capturados. |
+| `src/routes/valores.ts` | Rotas HTTP (GET /valores legado e POST /valores/sync para acionar a sincronizacao manualmente). |
+
+## Execucao
+1. Instale dependencias: `npm install`
+2. Ajuste o `.env`
+3. Inicie o servidor: `npm start`
+
+Logs esperados no boot:
+- Conexao com o MongoDB Atlas com identificacao do banco ativo
+- Resultado da sincronizacao inicial (processados, removidos, ignorados)
+- Confirmacao de que o watcher esta ativo
+- URL do servidor Express (porta 5004 por padrao)
+
+Para encerrar use `Ctrl+C`. O servidor fecha o watcher, encerra a conexao com o Mongo e termina o processo.
+
+## Sincronizacao automatica
+- Um novo documento inserido na colecao dispara o watcher.
+- A rotina executa: coleta -> validacao -> persistencia no Postgres -> remocao do documento no Mongo.
+- Insercoes em sequencia sao enfileiradas por `pendingSync`, evitando sincronizacoes paralelas.
+
+## Sincronizacao manual
+Dispare a rotina manualmente:
+
+```bash
+curl -X POST http://localhost:5004/valores/sync
+```
+
+A resposta contem o resumo (`processedDocuments`, `removedDocuments`, `skippedDocuments`, `errors`, etc.).
+
+### Testando pelo Postman
+1. Crie uma nova requisicao `POST` com a URL `http://localhost:5004/valores/sync`.
+2. Nenhum corpo e necessario (leave body vazio).
+3. Envie a requisicao; o JSON de resposta trara o mesmo resumo exibido no terminal.
+4. Se preferir salvar, adicione a requisicao em uma collection para repetir o teste apos novas leituras no Mongo.
+
+Para validar os dados persistidos no Atmos-backend:
+- Certifique-se de que o servidor Atmos-backend esta rodando (default `npm start` na pasta do outro projeto, porta `5000`).
+- No Postman ou navegador, acesse `http://localhost:5000/valor-capturado` (GET). A resposta deve listar os registros gravados pelo processador.
+
+## Desenvolvimento
+- Tipagem com TypeScript (`npx tsc --noEmit` para checagem).
+- Servidor rodando com `ts-node/esm` (sem hot reload).
+- Projeto usa modulos ES e importa as extensoes `.ts` explicitamente.
+
+## Troubleshooting
+- **Resumo zerado**: confira `MONGO_DB`/`MONGO_COLLECTION` e se ha documentos com `UUID` e `unixtime` validos.
+- **Estacao sem parametros**: cadastre os parametros no Atmos-backend (tabelas `parametro` e `tipo_parametro`).
+- **Erro de conexao com Postgres**: valide as credenciais `DB_*` e se o banco esta acessivel.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
+        "mongodb": "^6.20.0",
         "sequelize": "^6.37.7"
       },
       "devDependencies": {
@@ -58,6 +59,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.1.tgz",
+      "integrity": "sha512-6nZrq5kfAz0POWyhljnbWQQJQ5uT8oE2ddX303q1uY0tWsivWKgBDXBBvuFPwOqRRalXJuVO9EjOdVtuhLX0zg==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -215,6 +225,21 @@
       "integrity": "sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q==",
       "license": "MIT"
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -279,6 +304,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/bytes": {
@@ -750,6 +784,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
@@ -802,6 +842,62 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
+      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
     "node_modules/ms": {
@@ -888,6 +984,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -1191,6 +1296,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1214,6 +1328,18 @@
       "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
       "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -1334,6 +1460,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/wkx": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
         "mongodb": "^6.20.0",
+        "pg": "^8.16.3",
         "sequelize": "^6.37.7"
       },
       "devDependencies": {
@@ -967,11 +968,133 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/pg-connection-string": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
       "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
       "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1305,6 +1428,15 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1498,6 +1630,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "mongodb": "^6.20.0",
+    "pg": "^8.16.3",
     "sequelize": "^6.37.7"
   },
   "type": "module"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
+    "mongodb": "^6.20.0",
     "sequelize": "^6.37.7"
   },
   "type": "module"

--- a/src/config/mongo.ts
+++ b/src/config/mongo.ts
@@ -1,0 +1,52 @@
+import dotenv from 'dotenv';
+import { MongoClient } from 'mongodb';
+import type { Collection } from 'mongodb';
+
+dotenv.config();
+
+const { MONGO_URI, MONGO_COLLECTION } = process.env;
+
+if (!MONGO_URI) {
+  throw new Error('Variável de ambiente MONGO_URI não configurada.');
+}
+
+let mongoClient: MongoClient | null = null;
+
+export const connectMongoDB = async (): Promise<MongoClient> => {
+  if (mongoClient) {
+    return mongoClient;
+  }
+
+  const client = new MongoClient(MONGO_URI);
+  try {
+    await client.connect();
+    await client.db().command({ ping: 1 });
+    console.log('Conexão com MongoDB Atlas estabelecida com sucesso.');
+    mongoClient = client;
+    return mongoClient;
+  } catch (error) {
+    console.error('Falha ao conectar com o MongoDB Atlas:', error);
+    await client.close().catch(() => undefined);
+    throw error;
+  }
+};
+
+export const getMongoCollection = async (
+  collectionName = MONGO_COLLECTION,
+): Promise<Collection> => {
+  if (!collectionName) {
+    throw new Error('Nome da coleção do MongoDB não informado.');
+  }
+
+  const client = await connectMongoDB();
+  return client.db().collection(collectionName);
+};
+
+export const disconnectMongoDB = async (): Promise<void> => {
+  if (!mongoClient) {
+    return;
+  }
+
+  await mongoClient.close();
+  mongoClient = null;
+};

--- a/src/config/mongo.ts
+++ b/src/config/mongo.ts
@@ -1,52 +1,84 @@
 import dotenv from 'dotenv';
 import { MongoClient } from 'mongodb';
-import type { Collection } from 'mongodb';
+import type { Collection, Db } from 'mongodb';
 
+// Carrega as variáveis de ambiente a partir de um arquivo .env
 dotenv.config();
 
-const { MONGO_URI, MONGO_COLLECTION } = process.env;
+// Desestruturação das variáveis de ambiente MONGO_URI, MONGO_COLLECTION e MONGO_DB
+const { MONGO_URI, MONGO_COLLECTION, MONGO_DB } = process.env;
 
+// Verifica se a variável de ambiente MONGO_URI está definida, caso contrário, lança um erro
 if (!MONGO_URI) {
   throw new Error('Variável de ambiente MONGO_URI não configurada.');
 }
 
+// Inicializa uma variável para armazenar a instância do MongoClient
 let mongoClient: MongoClient | null = null;
+// Remove espaços em branco no nome do banco de dados, se houver
+const trimmedDbName = MONGO_DB?.trim();
 
+// Função que retorna a instância do banco de dados com base no cliente MongoDB
+const getDatabaseInstance = (client: MongoClient): Db => {
+  // Se o nome do banco de dados foi definido, usa esse nome, caso contrário, usa o banco padrão
+  return trimmedDbName ? client.db(trimmedDbName) : client.db();
+};
+
+// Função assíncrona para conectar ao MongoDB Atlas
 export const connectMongoDB = async (): Promise<MongoClient> => {
+  // Se a conexão já foi estabelecida, retorna o cliente existente
   if (mongoClient) {
     return mongoClient;
   }
 
+  // Cria uma nova instância do MongoClient usando a URI configurada
   const client = new MongoClient(MONGO_URI);
   try {
+    // Tenta se conectar ao MongoDB
     await client.connect();
-    await client.db().command({ ping: 1 });
-    console.log('Conexão com MongoDB Atlas estabelecida com sucesso.');
+    // Verifica se a conexão foi bem-sucedida fazendo um ping no banco de dados
+    await getDatabaseInstance(client).command({ ping: 1 });
+    // Se o nome do banco de dados foi definido, exibe uma mensagem com o nome do banco
+    const databaseInfo = trimmedDbName ? `banco ${trimmedDbName}` : 'banco padrão definido na conexão';
+    console.log(`Conexão com MongoDB Atlas estabelecida com sucesso (${databaseInfo}).`);
+    // Armazena o cliente de conexão para evitar conexões duplicadas
     mongoClient = client;
+    // Retorna o cliente conectado
     return mongoClient;
   } catch (error) {
+    // Caso ocorra algum erro ao conectar, exibe uma mensagem de erro
     console.error('Falha ao conectar com o MongoDB Atlas:', error);
+    // Fecha a conexão do cliente (se foi aberto) e ignora erros na tentativa de fechar
     await client.close().catch(() => undefined);
+    // Lança o erro para que o código que chamou a função possa tratá-lo
     throw error;
   }
 };
 
+// Função assíncrona para obter uma coleção específica do MongoDB
 export const getMongoCollection = async (
-  collectionName = MONGO_COLLECTION,
+  collectionName = MONGO_COLLECTION, // Usa o nome da coleção configurado no ambiente ou o nome passado como argumento
 ): Promise<Collection> => {
+  // Se o nome da coleção não foi informado, lança um erro
   if (!collectionName) {
     throw new Error('Nome da coleção do MongoDB não informado.');
   }
 
+  // Obtém a instância do cliente conectado ao MongoDB
   const client = await connectMongoDB();
-  return client.db().collection(collectionName);
+  // Retorna a coleção especificada dentro do banco de dados
+  return getDatabaseInstance(client).collection(collectionName);
 };
 
+// Função assíncrona para desconectar do MongoDB
 export const disconnectMongoDB = async (): Promise<void> => {
+  // Se a conexão não foi estabelecida, não faz nada
   if (!mongoClient) {
     return;
   }
 
+  // Fecha a conexão com o MongoDB
   await mongoClient.close();
+  // Após fechar a conexão, define o cliente como nulo
   mongoClient = null;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import express from "express";
+import type { Server } from "node:http";
 import router from "./routes/index.ts";
-import { connectMongoDB } from "./config/mongo.ts";
+import { connectMongoDB, disconnectMongoDB } from "./config/mongo.ts";
+import { startMongoWatcher, stopMongoWatcher } from "./services/mongoWatcher.ts";
+import { syncMongoToPostgres } from "./services/mongoToPostgresSync.ts";
 
 const app = express();
 const port = process.env.PORT || 5004;
@@ -12,9 +15,40 @@ app.use(router);
 const startServer = async (): Promise<void> => {
   try {
     await connectMongoDB();
-    app.listen(port, () => {
+    await startMongoWatcher();
+
+    const initialSummary = await syncMongoToPostgres();
+    if (initialSummary.totalDocuments > 0 || initialSummary.removedDocuments > 0) {
+      console.log(
+        `[MongoSync] Processamento inicial: ${initialSummary.processedDocuments}/${initialSummary.totalDocuments} documentos, ` +
+          `${initialSummary.removedDocuments} removidos.`,
+      );
+      if (initialSummary.skippedDocuments.length > 0) {
+        console.log(
+          `[MongoSync] Documentos ignorados na sincronização inicial: ${initialSummary.skippedDocuments.length}.`,
+        );
+      }
+      if (initialSummary.errors.length > 0) {
+        console.warn('[MongoSync] Erros na sincronização inicial:', initialSummary.errors);
+      }
+    }
+
+    const server: Server = app.listen(port, () => {
       console.log(`Servidor rodando em http://localhost:${port}`);
     });
+
+    const shutdown = async (): Promise<void> => {
+      console.log("Iniciando processo de desligamento do servidor...");
+      await stopMongoWatcher();
+      await disconnectMongoDB();
+      server.close(() => {
+        console.log("Servidor encerrado.");
+        process.exit(0);
+      });
+    };
+
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
   } catch (error) {
     console.error("Não foi possível iniciar o servidor devido a falha na conexão com o MongoDB Atlas.", error);
     process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import router from "./routes/index.ts";
+import { connectMongoDB } from "./config/mongo.ts";
 
 const app = express();
 const port = process.env.PORT || 5004;
@@ -8,6 +9,16 @@ app.use(express.json());
 
 app.use(router);
 
-app.listen(port, () => {
-  console.log(`Servidor rodando em http://localhost:${port}`);
-});
+const startServer = async (): Promise<void> => {
+  try {
+    await connectMongoDB();
+    app.listen(port, () => {
+      console.log(`Servidor rodando em http://localhost:${port}`);
+    });
+  } catch (error) {
+    console.error("Não foi possível iniciar o servidor devido a falha na conexão com o MongoDB Atlas.", error);
+    process.exit(1);
+  }
+};
+
+void startServer();

--- a/src/repository/postgresSyncRepository.ts
+++ b/src/repository/postgresSyncRepository.ts
@@ -1,0 +1,87 @@
+import { QueryTypes, Transaction } from 'sequelize';
+import { sequelize } from '../config/database.ts';
+
+// Define a interface para os registros de estação, com campos 'pk' e 'uuid'
+export interface StationRecord {
+  pk: number;
+  uuid: string;
+}
+
+// Define a interface para os registros de parâmetros da estação, com campos 'parametroPk', 'tipoParametroPk' e 'jsonId'
+export interface StationParameterRecord {
+  parametroPk: number;
+  tipoParametroPk: number;
+  jsonId: string;
+}
+
+// Define a interface para os dados de entrada de valores capturados, com campos 'unixtime', 'parametrosPk', 'valor' e 'estacaoId'
+export interface CapturedValueInput {
+  unixtime: Date;
+  parametrosPk: number;
+  valor: number;
+  estacaoId: number;
+}
+
+// Função assíncrona que busca uma estação pelo seu UUID no banco de dados
+export const findStationByUUID = async (uuid: string): Promise<StationRecord | null> => {
+  // Executa uma consulta SQL para buscar a estação com o UUID fornecido e retorna a primeira estação encontrada ou null se não houver resultados
+  const records = await sequelize.query<StationRecord>(
+    'SELECT pk, uuid FROM estacoes WHERE uuid = :uuid LIMIT 1',
+    {
+      replacements: { uuid }, // Substitui :uuid pela variável uuid fornecida como argumento
+      type: QueryTypes.SELECT, // Define o tipo da consulta como SELECT
+    },
+  );
+
+  // Retorna o primeiro registro encontrado ou null caso não haja resultados
+  return records[0] ?? null;
+};
+
+// Função assíncrona que busca os parâmetros de uma estação com base no seu ID
+export const fetchStationParameters = async (
+  stationPk: number,
+): Promise<Map<string, StationParameterRecord>> => {
+  // SQL para buscar os parâmetros da estação, unindo as tabelas 'parametro' e 'tipo_parametro' com base na chave estrangeira
+  const sql = 'SELECT parametro.pk AS "parametroPk",' +
+    ' parametro.tipo_parametro_pk AS "tipoParametroPk",' +
+    ' tipo_parametro.json_id AS "jsonId"' +
+    ' FROM parametro' +
+    ' INNER JOIN tipo_parametro ON tipo_parametro.pk = parametro.tipo_parametro_pk' +
+    ' WHERE parametro.estacao_est_pk = :stationPk';
+
+  // Executa a consulta SQL para buscar os parâmetros da estação com o ID fornecido
+  const records = await sequelize.query<StationParameterRecord>(sql, {
+    replacements: { stationPk }, // Substitui :stationPk pela variável stationPk fornecida como argumento
+    type: QueryTypes.SELECT, // Define o tipo da consulta como SELECT
+  });
+
+  // Retorna um Map onde a chave é o 'jsonId' e o valor é o registro de StationParameterRecord
+  return records.reduce((acc, record) => {
+    if (record.jsonId) {
+      acc.set(record.jsonId, record);
+    }
+    return acc;
+  }, new Map<string, StationParameterRecord>());
+};
+
+// Função assíncrona que insere um novo valor capturado no banco de dados
+export const insertCapturedValue = async (
+  data: CapturedValueInput, // Dados de entrada para o valor capturado
+  transaction?: Transaction, // Transação opcional, usada para garantir a atomicidade das operações
+): Promise<void> => {
+  // SQL para inserir os dados de valor capturado na tabela 'valor_capturado'
+  const sql = 'INSERT INTO valor_capturado (unixtime, "Parametros_pk", valor, estacao_id)' +
+    ' VALUES (:unixtime, :parametrosPk, :valor, :estacaoId)';
+
+  // Executa a consulta SQL para inserir os dados fornecidos na tabela 'valor_capturado'
+  await sequelize.query(sql, {
+    replacements: {
+      unixtime: data.unixtime,        // Substitui :unixtime pelos dados fornecidos
+      parametrosPk: data.parametrosPk, // Substitui :parametrosPk pelos dados fornecidos
+      valor: data.valor,               // Substitui :valor pelos dados fornecidos
+      estacaoId: data.estacaoId,       // Substitui :estacaoId pelos dados fornecidos
+    },
+    type: QueryTypes.INSERT, // Define o tipo da consulta como INSERT
+    transaction,             // Se fornecida, usa a transação para garantir a atomicidade
+  });
+};

--- a/src/routes/valores.ts
+++ b/src/routes/valores.ts
@@ -3,6 +3,7 @@ import type {Request, Response } from "express";
 import { TipoParametroRepository } from "../repository/tipoParametroRepository.ts";
 import { EstacaoRepository } from "../repository/estacaoRepository.ts";
 import { ValorCapturadoRepository } from "../repository/valorCapturadoRepository.ts";
+import { syncMongoToPostgres } from "../services/mongoToPostgresSync.ts";
 
 const router = Router();
 const tipoParametroRepository: TipoParametroRepository = new TipoParametroRepository()
@@ -52,6 +53,16 @@ router.get("/", async (req: Request, res: Response) => {
     }
 
     return res.status(200).send({ "message": "Sucesso no registro dos parâmetros" });
+});
+
+router.post("/sync", async (_req: Request, res: Response) => {
+    try {
+        const summary = await syncMongoToPostgres();
+        return res.status(200).json(summary);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "Erro desconhecido";
+        return res.status(500).json({ error: message });
+    }
 });
 
 export default router;

--- a/src/services/mongoToPostgresSync.ts
+++ b/src/services/mongoToPostgresSync.ts
@@ -1,0 +1,311 @@
+import { ObjectId } from 'mongodb';
+import type { WithId } from 'mongodb';
+import { getMongoCollection } from '../config/mongo.ts';
+import { sequelize } from '../config/database.ts';
+import {
+  findStationByUUID,
+  fetchStationParameters,
+  insertCapturedValue,
+  type StationRecord,
+  type StationParameterRecord,
+} from '../repository/postgresSyncRepository.ts';
+
+// Interface para representar um documento do MongoDB relacionado a uma estação atmosférica
+interface MongoAtmosDocument extends WithId<Record<string, unknown>> {
+  UUID?: string;
+  unixtime?: number | string | Date;
+}
+
+// Interface para armazenar informações sobre documentos que foram ignorados durante a sincronização
+interface SyncSkipInfo {
+  id: string;
+  reason: string;
+  details?: string;
+}
+
+// Interface para armazenar informações sobre erros ocorridos durante a sincronização
+interface SyncErrorInfo {
+  id: string;
+  error: string;
+}
+
+// Interface para representar o resumo da sincronização entre MongoDB e PostgreSQL
+export interface SyncSummary {
+  totalDocuments: number; // Total de documentos processados
+  processedDocuments: number; // Total de documentos processados com sucesso
+  insertedValues: number; // Total de valores inseridos no PostgreSQL
+  skippedDocuments: SyncSkipInfo[]; // Documentos que foram ignorados durante a sincronização
+  errors: SyncErrorInfo[]; // Erros encontrados durante o processo
+  ignoredValues: number; // Quantidade de valores ignorados por não serem válidos
+  removedDocuments: number; // Total de documentos removidos do MongoDB após sincronização
+}
+
+// Conjunto de campos a serem ignorados durante a sincronização
+const FIELDS_TO_IGNORE = new Set(['_id', 'UUID', 'unixtime']);
+
+// Cache para armazenar informações sobre as estações e seus parâmetros, evitando consultas repetidas
+const stationCache = new Map<string, StationRecord | null>();
+const parameterCache = new Map<number, Map<string, StationParameterRecord>>();
+
+// Função para converter valores de "unixtime" em objetos Date
+const parseUnixTime = (value: unknown): Date | null => {
+  // Se já for uma instância de Date, retorna diretamente
+  if (value instanceof Date) {
+    return value;
+  }
+
+  // Se o valor não for número ou string, retorna null
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    return null;
+  }
+
+  // Tenta converter o valor para número
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+
+  // Se o valor for um timestamp em segundos, converte para milissegundos
+  const millis = parsed > 1_000_000_000_000 ? parsed : parsed * 1000;
+  const date = new Date(millis);
+  // Verifica se a data é válida e retorna, caso contrário, retorna null
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+// Função para converter valores numéricos representados como string ou número
+const parseNumericValue = (value: unknown): number | null => {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  return null;
+};
+
+// Função para obter a estação do MongoDB usando o UUID, armazenando em cache para evitar consultas repetidas
+const getStation = async (uuid: string): Promise<StationRecord | null> => {
+  // Verifica se a estação já está no cache, caso contrário, realiza a busca no banco
+  if (stationCache.has(uuid)) {
+    return stationCache.get(uuid) ?? null;
+  }
+
+  const found = await findStationByUUID(uuid);
+  stationCache.set(uuid, found ?? null);
+  return found ?? null;
+};
+
+// Função para obter os parâmetros da estação, armazenando em cache para evitar consultas repetidas
+const getStationParameters = async (
+  stationPk: number,
+): Promise<Map<string, StationParameterRecord>> => {
+  if (parameterCache.has(stationPk)) {
+    return parameterCache.get(stationPk) ?? new Map<string, StationParameterRecord>();
+  }
+
+  const parameters = await fetchStationParameters(stationPk);
+  parameterCache.set(stationPk, parameters);
+  return parameters;
+};
+
+// Função para garantir que o ID do documento seja uma string válida
+const ensureDocumentId = (id: ObjectId | undefined, fallback: string): string => {
+  return id ? id.toString() : fallback;
+};
+
+// Função principal que sincroniza os dados do MongoDB para o PostgreSQL
+export const syncMongoToPostgres = async (): Promise<SyncSummary> => {
+  // Obtém a coleção do MongoDB
+  const collection = await getMongoCollection();
+  const cursor = collection.find<MongoAtmosDocument>({});
+
+  // Inicializa o resumo da sincronização
+  const summary: SyncSummary = {
+    totalDocuments: 0,
+    processedDocuments: 0,
+    insertedValues: 0,
+    skippedDocuments: [],
+    errors: [],
+    ignoredValues: 0,
+    removedDocuments: 0,
+  };
+
+  const documentsToRemove: ObjectId[] = [];
+  let missingIdForRemoval = 0;
+
+  // Percorre todos os documentos no MongoDB
+  for await (const document of cursor) {
+    summary.totalDocuments += 1;
+    const docId = ensureDocumentId(document._id, 'document-' + summary.totalDocuments);
+
+    // Função para marcar documentos para remoção
+    const markForRemoval = (): void => {
+      if (document._id) {
+        documentsToRemove.push(document._id);
+      } else {
+        missingIdForRemoval += 1;
+      }
+    };
+
+    const uuid = typeof document.UUID === 'string' ? document.UUID.trim() : '';
+    // Se o UUID estiver ausente, ignora o documento
+    if (!uuid) {
+      summary.skippedDocuments.push({
+        id: docId,
+        reason: 'UUID ausente',
+      });
+      markForRemoval();
+      continue;
+    }
+
+    let station: StationRecord | null;
+    try {
+      station = await getStation(uuid);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido ao buscar estação';
+      summary.errors.push({
+        id: docId,
+        error: errorMessage,
+      });
+      continue;
+    }
+
+    // Se a estação não for encontrada, ignora o documento
+    if (!station) {
+      summary.skippedDocuments.push({
+        id: docId,
+        reason: 'Estação não encontrada',
+        details: 'UUID ' + uuid,
+      });
+      markForRemoval();
+      continue;
+    }
+
+    let parameters: Map<string, StationParameterRecord>;
+    try {
+      parameters = await getStationParameters(station.pk);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido ao buscar parâmetros';
+      summary.errors.push({
+        id: docId,
+        error: errorMessage,
+      });
+      continue;
+    }
+
+    // Se não houver parâmetros vinculados à estação, ignora o documento
+    if (parameters.size === 0) {
+      summary.skippedDocuments.push({
+        id: docId,
+        reason: 'Estação sem parâmetros vinculados',
+        details: 'UUID ' + uuid,
+      });
+      markForRemoval();
+      continue;
+    }
+
+    // Tenta converter o valor de 'unixtime' para um objeto Date válido
+    const unixTimeDate = parseUnixTime(document.unixtime);
+    if (!unixTimeDate) {
+      summary.skippedDocuments.push({
+        id: docId,
+        reason: 'Unixtime inválido',
+        details: 'Valor: ' + String(document.unixtime),
+      });
+      markForRemoval();
+      continue;
+    }
+
+    // Filtra os campos do documento que não devem ser processados
+    const entries = Object.entries(document).filter(function extractValidEntries(entry) {
+      return !FIELDS_TO_IGNORE.has(entry[0]);
+    });
+
+    // Lista para armazenar os valores válidos a serem persistidos no PostgreSQL
+    const valuesToPersist: Array<{ key: string; valor: number; parametrosPk: number }> = [];
+
+    // Processa cada entrada do documento
+    for (const entry of entries) {
+      const key = entry[0];
+      const rawValue = entry[1];
+
+      const parameter = parameters.get(key);
+      if (!parameter) {
+        summary.ignoredValues += 1;
+        continue;
+      }
+
+      const numericValue = parseNumericValue(rawValue);
+      if (numericValue === null) {
+        summary.ignoredValues += 1;
+        continue;
+      }
+
+      valuesToPersist.push({
+        key,
+        valor: numericValue,
+        parametrosPk: parameter.parametroPk,
+      });
+    }
+
+    // Se não houver valores válidos para persistir, ignora o documento
+    if (valuesToPersist.length === 0) {
+      summary.skippedDocuments.push({
+        id: docId,
+        reason: 'Nenhum parâmetro válido encontrado',
+        details: 'UUID ' + uuid,
+      });
+      markForRemoval();
+      continue;
+    }
+
+    // Realiza a inserção dos valores capturados no PostgreSQL dentro de uma transação
+    try {
+      await sequelize.transaction(async (transaction) => {
+        for (const valueInfo of valuesToPersist) {
+          await insertCapturedValue(
+            {
+              unixtime: unixTimeDate,
+              parametrosPk: valueInfo.parametrosPk,
+              valor: valueInfo.valor,
+              estacaoId: station.pk,
+            },
+            transaction,
+          );
+        }
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Erro desconhecido ao inserir valores';
+      summary.errors.push({
+        id: docId,
+        error: errorMessage,
+      });
+      continue;
+    }
+
+    // Atualiza o resumo da sincronização
+    summary.processedDocuments += 1;
+    summary.insertedValues += valuesToPersist.length;
+    markForRemoval();
+  }
+
+  // Remove os documentos processados do MongoDB
+  if (documentsToRemove.length > 0) {
+    const deleteResult = await collection.deleteMany({ _id: { $in: documentsToRemove } });
+    summary.removedDocuments = deleteResult.deletedCount ?? 0;
+  }
+
+  // Registra qualquer erro relacionado à remoção de documentos sem _id
+  if (missingIdForRemoval > 0) {
+    summary.errors.push({
+      id: 'unknown',
+      error: `${missingIdForRemoval} documento(s) não puderam ser removidos por ausência de _id.`,
+    });
+  }
+
+  // Retorna o resumo da sincronização
+  return summary;
+};

--- a/src/services/mongoWatcher.ts
+++ b/src/services/mongoWatcher.ts
@@ -1,0 +1,109 @@
+import type { ChangeStream } from 'mongodb';
+import { getMongoCollection } from '../config/mongo.ts';
+import { syncMongoToPostgres } from './mongoToPostgresSync.ts';
+
+// Variável para armazenar a instância do ChangeStream (fluxo de mudanças) do MongoDB
+let changeStream: ChangeStream | null = null;
+// Variável de controle para indicar se a sincronização está em andamento
+let syncInProgress = false;
+// Variável de controle para indicar se há uma sincronização pendente enquanto outra está em andamento
+let pendingSync = false;
+
+// Função que loga um resumo da sincronização entre MongoDB e PostgreSQL
+const logSummary = (summary: Awaited<ReturnType<typeof syncMongoToPostgres>>): void => {
+  // Verifica se houve documentos processados ou removidos e loga o resumo da operação
+  if (summary.totalDocuments > 0 || summary.removedDocuments > 0) {
+    const message = '[MongoSync] Processados ' +
+      summary.processedDocuments + '/' + summary.totalDocuments + ', ' +
+      summary.removedDocuments + ' documento(s) removido(s). Ignorados: ' + summary.ignoredValues + '.';
+    console.log(message);
+  }
+
+  // Caso tenha ocorrido algum erro durante a sincronização, exibe um aviso no log
+  if (summary.errors.length > 0) {
+    console.warn('[MongoSync] Ocorreram erros durante a sincronização automática.', summary.errors);
+  }
+};
+
+// Função que dispara a sincronização entre MongoDB e PostgreSQL
+const triggerSync = async (): Promise<void> => {
+  // Verifica se já existe uma sincronização em andamento
+  if (syncInProgress) {
+    // Caso haja uma sincronização em andamento, marca que há uma sincronização pendente
+    pendingSync = true;
+    return;
+  }
+
+  // Marca que a sincronização está em andamento
+  syncInProgress = true;
+  try {
+    // Executa a função de sincronização e aguarda a resposta
+    const summary = await syncMongoToPostgres();
+    // Exibe o resumo da sincronização
+    logSummary(summary);
+  } catch (error) {
+    // Caso ocorra um erro durante a sincronização, exibe uma mensagem de erro
+    console.error('[MongoSync] Falha ao executar sincronização automática:', error);
+  } finally {
+    // Marca que a sincronização foi finalizada
+    syncInProgress = false;
+    // Caso haja uma sincronização pendente, chama a função de sincronização novamente
+    if (pendingSync) {
+      pendingSync = false;
+      void triggerSync();
+    }
+  }
+};
+
+// Função para iniciar o "watcher" (observador) de alterações no MongoDB
+export const startMongoWatcher = async (): Promise<void> => {
+  // Verifica se já existe um ChangeStream ativo
+  if (changeStream) {
+    return;
+  }
+
+  // Obtém a coleção do MongoDB que será observada
+  const collection = await getMongoCollection();
+  // Cria uma instância de ChangeStream para observar inserções na coleção
+  changeStream = collection.watch([{ $match: { operationType: 'insert' } }]);
+
+  // Evento que é acionado quando uma alteração do tipo 'insert' é detectada
+  changeStream.on('change', () => {
+    console.log('[MongoSync] Detecção de novo documento no MongoDB. Iniciando sincronização.');
+    // Dispara a sincronização assim que um novo documento é inserido
+    void triggerSync();
+  });
+
+  // Evento que é acionado quando ocorre um erro no ChangeStream
+  changeStream.on('error', async (error) => {
+    console.error('[MongoSync] Erro no change stream do MongoDB:', error);
+    // Caso ocorra um erro, tenta fechar o ChangeStream e reiniciar após 5 segundos
+    await stopMongoWatcher();
+    setTimeout(() => {
+      void startMongoWatcher().catch((err) => {
+        console.error('[MongoSync] Falha ao reiniciar watcher após erro:', err);
+      });
+    }, 5000);
+  });
+
+  // Evento que é acionado quando o ChangeStream é fechado
+  changeStream.on('close', () => {
+    changeStream = null;
+    console.log('[MongoSync] Change stream encerrado.');
+  });
+
+  console.log('[MongoSync] Watcher de inserts no MongoDB iniciado.');
+};
+
+// Função para parar o "watcher" de alterações no MongoDB
+export const stopMongoWatcher = async (): Promise<void> => {
+  // Verifica se há um ChangeStream ativo
+  if (changeStream) {
+    // Fecha o ChangeStream e captura qualquer erro durante o fechamento
+    await changeStream.close().catch((error) => {
+      console.error('[MongoSync] Erro ao fechar change stream:', error);
+    });
+    // Define a variável changeStream como null
+    changeStream = null;
+  }
+};


### PR DESCRIPTION
# AT-33: Adaptar processador de dados do MongoDB

## O que foi feito:
- ajustes para que o Mongo DB faça a captura dos dados e os envie para o Postgres no atmos-backend
- Regras de negócio:
  - caso exista a UUID da estação o dado será salvo
  - caso tenha pelo menos um parâmetro para a estação o dado também será salvo

## Como testar:
1. checar o readme dessa branch
    
## Checklist 
- checar o readme da branch
